### PR TITLE
Fix issue with clang --target when cross compiling using LLVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else # LLVM toolchain
 
 # Optional -$NUM version when multiple toolchains are installed
 ver := $(filter -%,$(LLVM))
-CC              := clang$(ver) $(if $(CROSS_COMPILE),--target=$(CROSS_COMPILE:%-=%))
+CC              := clang$(ver) $(if $(CROSS_COMPILE),--target=$(notdir $(CROSS_COMPILE:%-=%)))
 LD              := ld.lld$(ver)
 OBJCOPY         := llvm-objcopy$(ver)
 undefine ver


### PR DESCRIPTION
When using LLVM and cross compiling, the CC expands to:
clang --target=<target_triple>
Example of target triple: aarch64-linux-gnu.

However the current code assigning --target based on the
cross compiler does not work if we pass the full path to
CROSS_COMPILE. In this case the build fails.

Fix the issue so that when cross compiling using LLVM
only the basename of cross compiler path is used.

Signed-off-by: Michal Orzel <michal.orzel@arm.com>