### PR TITLE
pagetable-emulation: fix gcc and clang errors

### DIFF
--- a/tests/pagetable-emulation/main.c
+++ b/tests/pagetable-emulation/main.c
@@ -112,6 +112,7 @@ typedef union
         bool pkrs_ad:1;
 
         bool max:1; /* Must be last; upper boundary. */
+        unsigned int padding:20;
     };
 } __transparent pg_ctrl_t;
 

--- a/tests/xsa-304/main.c
+++ b/tests/xsa-304/main.c
@@ -123,7 +123,7 @@ void test_main(void)
         /* Alias 16M linear to 0, using 0's 4k mappings. */
         l2_identmap[8] = l2_identmap[0];
 
-        flush_tlb();
+        flush_tlb(false);
 
         stub(l2_identmap, &cond);
     }


### PR DESCRIPTION
This PR fixes errors reported by gcc and Clang for the pagetable-emulation test.