### PR TITLE
build: Avoid forcing -include arch/config.h into global CFLAGS/AFLAGS

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -59,8 +59,8 @@ define PERENV_setup
 AFLAGS_$($(1)_arch) := $$(COMMON_AFLAGS) $$(COMMON_AFLAGS-$($(1)_arch))
 CFLAGS_$($(1)_arch) := $$(COMMON_CFLAGS) $$(COMMON_CFLAGS-$($(1)_arch))
 
-AFLAGS_$(1) := $$(AFLAGS_$($(1)_arch)) $$(COMMON_AFLAGS-$(1)) -DCONFIG_ENV_$(1) -include arch/config.h
-CFLAGS_$(1) := $$(CFLAGS_$($(1)_arch)) $$(COMMON_CFLAGS-$(1)) -DCONFIG_ENV_$(1) -include arch/config.h
+AFLAGS_$(1) := $$(AFLAGS_$($(1)_arch)) $$(COMMON_AFLAGS-$(1)) -DCONFIG_ENV_$(1)
+CFLAGS_$(1) := $$(CFLAGS_$($(1)_arch)) $$(COMMON_CFLAGS-$(1)) -DCONFIG_ENV_$(1)
 
 link-$(1) := $(ROOT)/arch/x86/link-$(1).lds
 

--- a/include/xtf/compiler.h
+++ b/include/xtf/compiler.h
@@ -1,6 +1,12 @@
 #ifndef XTF_COMPILER_H
 #define XTF_COMPILER_H
 
+#if defined(CONFIG_ENV_pv64) || defined(CONFIG_ENV_pv32pae) || \
+    defined(CONFIG_ENV_hvm64) || defined(CONFIG_ENV_hvm32pae) || \
+    defined(CONFIG_ENV_hvm32pse) || defined(CONFIG_ENV_hvm32)
+#include <arch/config.h>
+#endif
+
 #ifdef __GNUC__
 #include <xtf/compiler-gcc.h>
 #endif

--- a/include/xtf/numbers.h
+++ b/include/xtf/numbers.h
@@ -6,6 +6,12 @@
 #ifndef XTF_NUMBERS_H
 #define XTF_NUMBERS_H
 
+#if defined(CONFIG_ENV_pv64) || defined(CONFIG_ENV_pv32pae) || \
+	defined(CONFIG_ENV_hvm64) || defined(CONFIG_ENV_hvm32pae) || \
+	defined(CONFIG_ENV_hvm32pse) || defined(CONFIG_ENV_hvm32)
+#include <arch/config.h>
+#endif
+
 /**
  * Create an integer usable in both C and Assembly, even when @p suf is
  * needed.


### PR DESCRIPTION
Stop forcing -include arch/config.h into global CFLAGS/AFLAGS and instead include architecture-specific arch/config.h only when in the header which requires them.

This prevents the build/language-server from seeing architecture-only headers unconditionally and fixes language-server failures and spurious parsing errors in IDEs caused by unconditional inclusion of architecture headers and missing arch config in certain builds.